### PR TITLE
Merge

### DIFF
--- a/DnlibToolsTests.cs
+++ b/DnlibToolsTests.cs
@@ -468,4 +468,29 @@ public class DnlibToolsTests
             throw ex;
         }
     }
+    
+    [Fact]
+    public void UpdateMethodTest_2()
+    {
+        //Load a module (e.g., the current assembly)
+        DnlibTools.LoadAssembly(_testAssemblyPath);
+        
+        var input = @"
+            ldc.i4 2055
+            ldc.i4.1
+            ldc.i4.1
+            newobj instance void [System.Runtime]System.DateTime::.ctor(int32, int32, int32)
+            ret
+        ";
+
+        try
+        {
+            var s = DnlibTools.UpdateMethodInstructions(7,5,input);
+            Assert.Contains("successfully", s);
+        }
+        catch (Exception ex)
+        {
+            throw ex;
+        }
+    }
 }

--- a/DnlibToolsTests.cs
+++ b/DnlibToolsTests.cs
@@ -451,7 +451,17 @@ public class DnlibToolsTests
     
         try
         {
-            DnlibTools.UpdateMethodInstructions(1,0,"nop\nret");
+            string s;
+            // Main, normal case
+            s = DnlibTools.UpdateMethodInstructions(1,0,"nop\nret");
+            Assert.Contains("successfully", s);
+            // cctor, ins < body ins and offset + ins > body ins
+            s = DnlibTools.UpdateMethodInstructions(7,5,"nop\nnop\nret");
+            Assert.Contains("successfully", s);
+            // cctor, ins > body ins
+            s = DnlibTools.UpdateMethodInstructions(7,0,"nop\nnop\nnop\nret");
+            Assert.Contains("successfully", s);
+
         }
         catch (Exception ex)
         {

--- a/InstructionParser.cs
+++ b/InstructionParser.cs
@@ -28,6 +28,7 @@ public class InstructionParser
                 map[opcode.Name.Replace(".", "")] = opcode;
             }
         }
+
         return map;
     }
 
@@ -65,7 +66,7 @@ public class InstructionParser
             if (!_opcodeMap.TryGetValue(opcodeName, out opcode))
                 throw new ArgumentException($"Unknown opcode: {opcodeName}");
         }
-            
+
 
         object operand = null;
         if (parts.Length > 1)
@@ -78,7 +79,7 @@ public class InstructionParser
     }
 
     // Parse the operand based on the opcode and operand string
-    private object ParseOperand(OpCode opcode, string operandStr)
+    internal object ParseOperand(OpCode opcode, string operandStr)
     {
         switch (opcode.OperandType)
         {
@@ -113,31 +114,157 @@ public class InstructionParser
             // Add more operand types as needed
             default:
                 return operandStr;
-                //throw new NotSupportedException($"Operand type {opcode.OperandType} not supported yet");
+            //throw new NotSupportedException($"Operand type {opcode.OperandType} not supported yet");
         }
     }
 
     // Resolve a method reference from a string (e.g., "System.Console::WriteLine")
+    // Resolve a method reference from a string
     private IMethod ResolveMethod(string methodStr)
     {
-        // Simplified parsing: assumes format "Namespace.Type::Method"
-        var parts = methodStr.Split(new[] { "::" }, StringSplitOptions.None);
-        if (parts.Length != 2)
-            throw new ArgumentException($"Invalid method format: {methodStr}");
+        try
+        {
+            // Handle more complex method signatures like:
+            // "instance void [System.Runtime]System.DateTime::.ctor(int32, int32, int32)"
 
-        var typeName = parts[0];
-        var methodName = parts[1];
+            // Extract assembly name if present
+            string asmName = null;
+            if (methodStr.Contains('[') && methodStr.Contains(']'))
+            {
+                int startIndex = methodStr.IndexOf('[') + 1;
+                int endIndex = methodStr.IndexOf(']');
+                if (startIndex < endIndex)
+                {
+                    asmName = methodStr.Substring(startIndex, endIndex - startIndex);
+                    methodStr = methodStr.Replace($"[{asmName}]", "");
+                }
+            }
 
-        var type = _module.Find(typeName, true);
-        if (type == null)
-            throw new ArgumentException($"Type not found: {typeName}");
+            // Check for instance/static method indicator
+            bool isInstance = false;
+            if (methodStr.StartsWith("instance "))
+            {
+                isInstance = true;
+                methodStr = methodStr.Substring("instance ".Length);
+            }
+            else if (methodStr.StartsWith("static "))
+            {
+                methodStr = methodStr.Substring("static ".Length);
+            }
 
-        // Find the method (simplified, assumes no overloads or parameters for brevity)
-        var method = type.FindMethod(methodName);
-        if (method == null)
-            throw new ArgumentException($"Method not found: {methodName} in {typeName}");
+            // Extract return type and remaining parts
+            int spaceIndex = methodStr.IndexOf(' ');
+            if (spaceIndex <= 0)
+                throw new ArgumentException($"Invalid method format: {methodStr}");
 
-        return _module.Import(method);
+            string returnType = methodStr.Substring(0, spaceIndex);
+            methodStr = methodStr.Substring(spaceIndex + 1);
+
+            // Split by :: to get type and method name with params
+            var parts = methodStr.Split(new[] { "::" }, StringSplitOptions.None);
+            if (parts.Length != 2)
+                throw new ArgumentException($"Invalid method format: {methodStr}");
+
+            string typeName = parts[0].Trim();
+            string methodNameWithParams = parts[1].Trim();
+
+            // Extract method name and parameters
+            int parenIndex = methodNameWithParams.IndexOf('(');
+            if (parenIndex < 0)
+                throw new ArgumentException($"Invalid method name format: {methodNameWithParams}");
+
+            string methodName = methodNameWithParams.Substring(0, parenIndex);
+            string paramsStr = methodNameWithParams.Substring(parenIndex + 1).TrimEnd(')');
+
+            // Get type reference
+            ITypeDefOrRef typeRef;
+            if (asmName != null)
+            {
+                // Try to find the assembly reference
+                var asmRef = _module.GetAssemblyRefs()
+                    .FirstOrDefault(a => a.Name == asmName || a.FullName == asmName);
+
+                if (asmRef == null)
+                    throw new ArgumentException($"Assembly reference not found: {asmName}");
+
+                // Create type reference with assembly reference
+                typeRef = new TypeRefUser(_module, typeName.Substring(typeName.LastIndexOf('.') + 1),
+                    typeName.Substring(0, typeName.LastIndexOf('.')),
+                    new AssemblyRefUser(asmRef));
+            }
+            else
+            {
+                // Look in the current module
+                typeRef = _module.Find(typeName, true);
+                if (typeRef == null)
+                    throw new ArgumentException($"Type not found: {typeName}");
+            }
+
+            // Parse parameters
+            var parameters = new List<TypeSig>();
+            if (!string.IsNullOrWhiteSpace(paramsStr))
+            {
+                var paramTypes = paramsStr.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var paramType in paramTypes)
+                {
+                    parameters.Add(ResolveTypeSignature(paramType.Trim()));
+                }
+            }
+
+            // Create method reference
+            var returnTypeSig = ResolveTypeSignature(returnType);
+
+            return new MemberRefUser(
+                _module,
+                methodName,
+                MethodSig.CreateInstance(returnTypeSig, parameters.ToArray()),
+                typeRef);
+        }
+        catch (Exception ex)
+        {
+            throw new ArgumentException($"Failed to resolve method: {methodStr}", ex);
+        }
+    }
+
+// Helper method to resolve type signatures like "int32", "string", etc.
+    private TypeSig ResolveTypeSignature(string typeSignature)
+    {
+        switch (typeSignature.ToLowerInvariant())
+        {
+            case "void": return _module.CorLibTypes.Void;
+            case "bool": return _module.CorLibTypes.Boolean;
+            case "char": return _module.CorLibTypes.Char;
+            case "int8":
+            case "sbyte": return _module.CorLibTypes.SByte;
+            case "uint8":
+            case "byte": return _module.CorLibTypes.Byte;
+            case "int16":
+            case "short": return _module.CorLibTypes.Int16;
+            case "uint16":
+            case "ushort": return _module.CorLibTypes.UInt16;
+            case "int32":
+            case "int": return _module.CorLibTypes.Int32;
+            case "uint32":
+            case "uint": return _module.CorLibTypes.UInt32;
+            case "int64":
+            case "long": return _module.CorLibTypes.Int64;
+            case "uint64":
+            case "ulong": return _module.CorLibTypes.UInt64;
+            case "float32":
+            case "single":
+            case "float": return _module.CorLibTypes.Single;
+            case "float64":
+            case "double": return _module.CorLibTypes.Double;
+            case "string": return _module.CorLibTypes.String;
+            case "object": return _module.CorLibTypes.Object;
+            default:
+                // Try to resolve as a custom type
+                var type = _module.Find(typeSignature, true);
+                if (type != null)
+                    return type.ToTypeSig();
+
+                throw new ArgumentException($"Unsupported type signature: {typeSignature}");
+        }
     }
 
     // Resolve a type reference from a string (e.g., "System.Object")

--- a/InstructionParserTest.cs
+++ b/InstructionParserTest.cs
@@ -1,4 +1,6 @@
-﻿using dnlib.DotNet;
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using dnlib.DotNet;
 using MCPPOC;
 using Xunit;
 
@@ -19,6 +21,86 @@ public class InstructionParserTest
         var input = @"
             ldstr ""Hello, World!""
             call System.Console::WriteLine
+            ret
+        ";
+
+        try
+        {
+            var instructions = parser.ParseInstructions(input);
+            foreach (var instr in instructions)
+            {
+                Console.WriteLine($"Parsed: {instr}");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw ex;
+        }
+    }
+    
+    [Fact]
+    public void ParseOperatorTest()
+    {
+        // Load reference assembly module for resolving types
+        // var assemblyPath = typeof(Program).Assembly.Location;
+        // var resolver = new AssemblyResolver();
+        // var moduleContext = new ModuleContext(resolver);
+        //
+        // // Create an assembly resolver that can find referenced assemblies
+        // resolver.DefaultModuleContext = moduleContext;
+        // resolver.EnableTypeDefCache = true;
+        //
+        // // Load the main module
+        // var module = ModuleDefMD.Load(assemblyPath, moduleContext);
+        // resolver.AddToCache(module);
+        //
+        // // Load referenced assemblies
+        // foreach (var asmRef in module.GetAssemblyRefs())
+        // {
+        //     try
+        //     {
+        //         // Resolve and load the referenced assembly
+        //         var assembly = resolver.Resolve(asmRef, module);
+        //         if (assembly != null)
+        //         {
+        //             Console.WriteLine($"Loaded reference: {asmRef.Name}");
+        //         }
+        //         
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Console.WriteLine($"Failed to load assembly {asmRef.Name}: {ex.Message}");
+        //     }
+        // }
+        var module = ModuleDefMD.Load(typeof(Program).Assembly.Location);
+        
+        // var consoleType = new TypeRefUser(module, "System", "DateTime");
+        // var type = module.Find("System.Console", true);
+        // if (type == null)
+        //     throw new ArgumentException($"Type not found");
+
+
+        var parser = new InstructionParser(module);
+        
+        var input = "instance void [System.Runtime]System.DateTime::.ctor(int32, int32, int32)";
+        var opcode = dnlib.DotNet.Emit.OpCodes.Newobj;
+        var result = parser.ParseOperand(opcode, input);
+        Assert.NotNull(result);
+    }
+    
+    [Fact]
+    public void ParseInstructionsTest_2()
+    {
+        var module = ModuleDefMD.Load(typeof(Program).Assembly.Location);
+
+        var parser = new InstructionParser(module);
+
+        // Example input string
+        var input = @"
+            ldc.i4 2055
+            ldc.i4.1
+            ldc.i4.1
+            newobj instance void [System.Runtime]System.DateTime::.ctor(int32, int32, int32)
             ret
         ";
 

--- a/Program.cs
+++ b/Program.cs
@@ -926,7 +926,16 @@ public static class DnlibTools
             return $"Instruction at offset {offset} not found in method {method.FullName}.";
         
         // Parse the new instruction
-        var ins = parser.ParseSingleInstruction(newInstruction);
+        Instruction ins = null;
+        try
+        {
+            ins = parser.ParseSingleInstruction(newInstruction);
+        }
+        catch (Exception ex)
+        {
+            return $"Failed to parse new instruction: {ex.Message}";
+        }
+
         if (ins == null )
             return $"Failed to parse new instruction: {newInstruction}";
 
@@ -982,7 +991,16 @@ public static class DnlibTools
             return $"Instruction at offset {offset} not found in method {method.FullName}.";
         
         // Parse the new instruction
-        var newInstructions = parser.ParseInstructions(newInstruction);
+        List<Instruction> newInstructions = new List<Instruction>();
+        try
+        {
+            newInstructions = parser.ParseInstructions(newInstruction);
+        }
+        catch (Exception ex)
+        {
+            return $"Failed to parse new instructions: {ex.Message}";
+        }
+
         if (newInstructions == null || newInstructions.Count == 0)
             return $"Failed to parse new instruction: {newInstruction}";
 


### PR DESCRIPTION
This pull request introduces significant enhancements and fixes to the dnlib-based instruction parsing and method updating functionality, along with expanded test coverage and improved error handling. The changes primarily focus on improving the robustness of method resolution, expanding the parsing capabilities, and adding new features like field reference searching.

### Improvements to `InstructionParser`:

* Enhanced the `ResolveMethod` method to handle complex method signatures, including support for assembly references, instance/static method indicators, and parameterized methods. A helper method `ResolveTypeSignature` was added for resolving type signatures.
* Made the `ParseOperand` method `internal` to allow access from test code.

### Enhancements to `Program.cs`:

* Improved the `LoadAssembly` method to resolve and cache referenced assemblies, ensuring dependencies are properly loaded.
* Updated `UpdateMethodInstructions` to handle methods without bodies by creating a new `CilBody`, and added logic to replace or extend instructions based on their length. [[1]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL974-R1029) [[2]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL1001-R1118)
* Added a new `FindFieldReferences` method to locate all usages of a specified field within the loaded assembly.

### Expanded Test Coverage:

* Added new test cases in `InstructionParserTest.cs` to validate parsing of complex instructions (`ParseOperatorTest`) and full instruction parsing across methods (`ParseInstructions_FullTest`).
* Introduced `UpdateMethodTest_2` in `DnlibToolsTests.cs` to test more complex scenarios for method instruction updates.

### Bug Fixes and Code Quality:

* Improved error handling in `UpdateMethodInstructions` and `UpdateMethodInstruction` by catching and returning detailed error messages for parsing failures. [[1]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL929-R964) [[2]](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bL974-R1029)
* Minor cleanup in `InitializeOpcodeMap` to remove unnecessary whitespace.